### PR TITLE
Made the board screen responsive.

### DIFF
--- a/saylua/context_processors.py
+++ b/saylua/context_processors.py
@@ -44,6 +44,15 @@ def inject_random_image():
 
 
 @app.context_processor
+def inject_truncate():
+    def truncate(s, maxlen=50):
+        if len(s) > maxlen:
+            return (s[:maxlen] + '...')
+        return s
+    return dict(truncate=truncate)
+
+
+@app.context_processor
 def inject_user_from_key():
     def user_from_key(key):
         if type(key) is str or type(key) is unicode: # noqa

--- a/saylua/modules/forums/static-source/scss/board.scss
+++ b/saylua/modules/forums/static-source/scss/board.scss
@@ -1,111 +1,123 @@
 @import 'assets/variables';
 @import 'assets/transitions';
+@import 'assets/utils';
 
-h2.forum-board-header {
-  display: flex;
-  margin-bottom: 0.5em;
-  padding-top: 1em;
-  padding-bottom: 0;
+a.write-thread-link {
+  font-size: $baseFontSize;
+  display: block;
+  margin: auto;
+  text-align: center;
+}
 
-  align-items: flex-end;
+.forum-thread-icon {
+  width: 3.2rem;
+  margin: 0 0.8rem;
+  text-align: center;
 
-  .forum-board-header-icon {
-    overflow: hidden;
-    height: 2.8rem;
-    margin-right: 0.8rem;
+  flex-grow: 0;
+  flex-shrink: 0;
 
-    flex-grow: 0;
-    flex-shrink: 0;
-    img {
-      width: 3.2rem;
-      height: 3.2rem;
-    }
-  }
+  transition: transform 1s;
+  transition-delay: 0.1s;
+  transform-origin: 50% 100%;
 
-  .forum-board-header-content {
-    display: flex;
-
-    align-items: baseline;
-    flex-grow: 1;
-    flex-shrink: 0;
-    justify-content: space-between;
-  }
-
-  a.write-thread-link {
-    font-size: $baseFontSize;
+  &:hover {
+    transform: scale(1.3, 1.3);
   }
 }
 
-.forum-board-table {
+.forum-thread-content {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+h2.forum-board-header {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  margin: 0.5em 0;
+  padding: 0;
+
+  .forum-thread-icon {
+    overflow-y: hidden;
+    height: 2.8rem;
+  }
+
+  .forum-thread-content {
+    align-items: baseline;
+  }
+
+  .forum-thread-replies,
+  .forum-latest-post {
+    font-size: $baseFontSize;
+    line-height: 120%;
+    @media (max-width: 500px) {
+      font-size: $smallFontSize;
+    }
+  }
+}
+
+.forum-board-header,
+.forum-thread {
   width: 100%;
-  margin-bottom: 4rem;
-  border-collapse: collapse;
-
-  td, th {
-    padding: 0.5em 0.4rem;
-  }
-
-  th {
-    font-size: $smallFontSize;
-    font-weight: normal;
-    text-align: left;
-    background: none;
-  }
-
-  tr.alternating-row {
-    @include fast-color-trans;
-    &:nth-child(even) {
-      background: $mainSoftestColor;
-    }
-
-    &.highlight:nth-child(n) {
-      background-color: $highlightSoftColor;
-    }
-
-    &.highlight:nth-child(even) {
-      background-color: $highlightColor;
-    }
-
-    // Note: We need the nth-child(n) to overwrite nth-child(even)
-    &:nth-child(n):hover {
-      background-color: $accentSoftColor;
-    }
-  }
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0.5em 0;
 
   .forum-thread-info {
-    width: 50%;
+    flex-grow: 1;
+    flex-shrink: 1;
 
-    a {
-      line-height: normal;
+    a.forum-thread-title {
+      line-height: 120%;
       display: block;
       width: 100%;
-      height: 100%;
-      text-decoration: none;
+      font-size: 1.6rem;
     }
 
-    a:hover .forum-thread-link {
-      display: block;
-      width: 100%;
-      text-decoration: underline;
-    }
-
-    a small,
-    a:hover small {
+    small {
+      line-height: 100%;
       display: block;
       width: 100%;
       margin: 0.5rem 0;
-      text-decoration: none;
-      color: $black;
     }
   }
 
-  .forum-thread-icon {
-    width: 4.8rem;
+  .forum-thread-replies {
+    flex-grow: 0;
+    flex-shrink: 0;
     text-align: center;
+    width: 20%;
+    @media (max-width: 500px) {
+      font-size: $smallFontSize;
+    }
   }
 
   .forum-latest-post {
-    font-size: 1.2rem;
-    width: 25%;
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: 35%;
+    img {
+      width: 3.2rem;
+      height: 3.2rem;
+
+      @media (max-width: 500px) {
+        display: none;
+      }
+    }
   }
+
+  .forum-thread-info,
+  .forum-thread-replies,
+  .forum-thread-latest-post {
+    padding-right: 0.4rem;
+  }
+}
+
+.forum-thread {
+  @extend %alternating-item;
 }

--- a/saylua/modules/forums/static-source/scss/main.scss
+++ b/saylua/modules/forums/static-source/scss/main.scss
@@ -61,14 +61,11 @@ ul.forum-main-list {
         align-items: baseline;
         flex-grow: 1;
         justify-content: space-between;
+      }
 
+      @media (max-width: 500px) {
         .latest-post-header {
-          font-size: 1.2rem;
-          line-height: 120%;
-          width: 40%;
-          @media (max-width: 500px) {
-            display: none;
-          }
+          display: none;
         }
       }
     }
@@ -88,52 +85,6 @@ ul.forum-main-list {
 
     flex-grow: 0;
     flex-shrink: 0;
-  }
-
-  .forum-board-info {
-    display: flex;
-    flex-direction: row;
-
-    align-items: center;
-    flex-grow: 1;
-    flex-shrink: 1;
-
-    @media (max-width: 500px) {
-      flex-direction: column;
-
-      align-items: stretch;
-
-      .forum-latest-post {
-        width: 100%;
-        padding-top: 1em;
-
-        img {
-          width: 3rem;
-          height: 3rem;
-        }
-      }
-    }
-  }
-
-  .forum-latest-post {
-    font-size: 1.2rem;
-    line-height: 150%;
-    display: flex;
-    flex-direction: row;
-    width: 40%;
-
-    align-items: center;
-    flex-grow: 0;
-    flex-shrink: 0;
-
-    img {
-      width: 5rem;
-      height: 5rem;
-      margin-right: 0.8rem;
-      border: $mainSofterColor 1px dotted;
-
-      flex-shrink: 0;
-    }
   }
 
   a.forum-board-text {
@@ -160,4 +111,36 @@ ul.forum-main-list {
       border: 0;
     }
   }
+}
+
+.forum-row-content {
+  display: flex;
+  flex-direction: row;
+
+  align-items: center;
+  flex-grow: 1;
+  flex-shrink: 1;
+  justify-content: space-between;
+
+  @media (max-width: 500px) {
+    flex-direction: column;
+
+    align-items: stretch;
+
+    .forum-latest-post {
+      width: 100%;
+      padding-top: 1em;
+
+      img {
+        width: 3rem;
+        height: 3rem;
+      }
+    }
+  }
+}
+
+.latest-post-header {
+  font-size: $baseFontSize;
+  line-height: 120%;
+  width: 40%;
 }

--- a/saylua/modules/forums/static-source/scss/shared.scss
+++ b/saylua/modules/forums/static-source/scss/shared.scss
@@ -1,7 +1,32 @@
+@import 'assets/variables';
+
+// Used in board.html and thread.html
 .forum-breadcrumb {
+  font-size: 1.8rem;
   display: block;
   margin: auto;
-  text-align: center;
-  font-size: 1.8rem;
   margin-bottom: 2em;
+  text-align: center;
+}
+
+// Used in main.html and board.html
+.forum-latest-post {
+  font-size: $smallFontSize;
+  line-height: 150%;
+  display: flex;
+  flex-direction: row;
+  width: 40%;
+
+  align-items: center;
+  flex-grow: 0;
+  flex-shrink: 0;
+
+  img {
+    width: 5rem;
+    height: 5rem;
+    margin-right: 0.8rem;
+    border: $mainSofterColor 1px dotted;
+
+    flex-shrink: 0;
+  }
 }

--- a/saylua/modules/forums/templates/board.html
+++ b/saylua/modules/forums/templates/board.html
@@ -9,81 +9,73 @@
 <span class="forum-breadcrumb">
   <a href="/forums/">Forums</a> &#187; {{ board.title }}
 </span>
-<div class="center">
-  {{ pagination(page_count=page_count) }}
-</div>
 
+<a class="write-thread-link" href="#write-thread">
+  <img src="/static/img/icons/pencil.png">
+  Make a New Thread
+</a>
 
 <h2 class="forum-board-header">
-  <div class="forum-board-header-icon">
+  <div class="forum-thread-icon">
     <img src="{{ random_item_image() }}" />
   </div>
-  <div class="forum-board-header-content">
-    Threads in {{ board.title }}
-    <a class="write-thread-link" href="#write-thread">
-      <img src="/static/img/icons/pencil.png">
-      Make a New Thread
-    </a>
+  <div class="forum-thread-content">
+    <div class="forum-thread-info">
+      {{ board.title }}
+    </div>
+    <div class="forum-thread-replies">
+      Replies
+    </div>
+    <div class="forum-latest-post">
+      Latest Post
+    </div>
   </div>
 </h2>
-<table class="forum-board-table">
-  <tr>
-    <th>
-    </th>
-    <th>
-      Thread Title
-    </th>
-    <th>
-      Replies
-    </th>
-    <th>
-      Started By
-    </th>
-    <th>
-      Last Post
-    </th>
-  </tr>
-
-  {% for thread in threads %}
-  <tr class="alternating-row {% if thread.is_pinned %} highlight{% endif %}">
-    <td class="forum-thread-icon">
-      {% if thread.is_pinned %}
-      <img src="/static/img/icons/pin.png">
-      {% endif %}
-      {% if thread.is_locked %}
-      <img src="/static/img/icons/lock.png">
-      {% endif %}
-    </td>
-    <td class="forum-thread-info">
-      <a href="/forums/thread/{{ thread.key.id() }}/">
-        <span class="forum-thread-link">{{ thread.title }}</span>
-        <small>Created on {{ thread.created_time|expanded_relative_time }}</small>
+{% for thread in threads %}
+<div class="forum-thread">
+  <div class="forum-thread-icon">
+    <img src="/static/img/icons/lock.png" />
+    {% if thread.is_pinned %}
+    <img src="/static/img/icons/pin.png">
+    {% endif %}
+    {% if thread.is_locked %}
+    <img src="/static/img/icons/lock.png">
+    {% endif %}
+  </div>
+  <div class="forum-thread-content">
+    <div class="forum-thread-info">
+      <a href="/forums/thread/{{ thread.key.id() }}/" class="forum-thread-title">
+        {{ thread.title }}
       </a>
-    </td>
-    <td>
+      <small>
+        Started by <a href="/user/{{ thread.creator_key|name_from_key_string }}">{{ thread.creator_key|name_from_key_string }}</a>
+        <span class="line">({{ thread.created_time|relative_time }})</span>
+      </small>
+    </div>
+    <div class="forum-thread-replies">
       {{ thread.key.id()|count_thread_posts - 1 }}
-    </td>
-    <td>
-      <a href="/user/{{ thread.creator_key|name_from_key_string }}">{{ thread.creator_key|name_from_key_string }}</a>
-    </td>
-    {% set last_post = thread.key.id()|last_post_thread %}
-    <td class="forum-latest-post">
+    </div>
+    <div class="forum-latest-post">
+      {% set last_post = thread.key.id()|last_post_thread %}
       {% if last_post is not none %}
-      by <a href="/user/{{ last_post.creator_key|name_from_key_string }}">
-        {{ last_post.creator_key|name_from_key_string }}</a>
-       {{ last_post.created_time|relative_time }}
+      <img src="{{ random_pet_image() }}" />
+      <p>
+        by <a href="/user/{{ last_post.creator_key|name_from_key_string }}">
+          {{ last_post.creator_key|name_from_key_string }}</a>
+        <span class="line">({{ last_post.created_time|relative_time }})</span>
+      </p>
       {% endif %}
-    </td>
-  </tr>
-  {% endfor %}
-</table>
+    </div>
+  </div>
+</div>
+{% endfor %}
 
 <div class="center">
 {{ pagination(page_count=page_count) }}
 </div>
 
 <h2 class="forum-board-header" id="write-thread">
-  <div class="forum-board-header-icon">
+  <div class="forum-thread-icon">
     <img src="{{ random_item_image() }}" />
   </div>
   Make a New Thread

--- a/saylua/modules/forums/templates/main.html
+++ b/saylua/modules/forums/templates/main.html
@@ -32,7 +32,7 @@
   {% for board in forum_block[1] %}
   <li class="forum-board-row">
     <img src="{{ random_item_image() }}" class="forum-board-icon faded" />
-    <div class="forum-board-info">
+    <div class="forum-row-content">
       <a href="/forums/board/{{ board.url_title }}/" class="forum-board-text">
         <span class="forum-board-link">{{ board.title }}</span>
         <p>
@@ -47,7 +47,7 @@
           <a href="/forums/thread/{{ last_post.thread_id }}">{{ (last_post.thread_id|thread_by_id).title }}
           </a> by <a href="/user/{{ last_post.creator_key|name_from_key_string }}">
             {{ last_post.creator_key|name_from_key_string }}</a>
-          on {{ last_post.created_time|show_datetime }}
+          <span class="line">({{ last_post.created_time|relative_time }})</span>
         </p>
         {% endif %}
       </div>

--- a/saylua/modules/forums/templates/thread.html
+++ b/saylua/modules/forums/templates/thread.html
@@ -6,10 +6,10 @@
 {% endblock %}
 {% block body %}
 <h1>{{ thread.title }}</h1>
-<span class="breadcrumb">
+<span class="forum-breadcrumb">
   <a href="/forums/">Forums</a> &#187;
   <a href="/forums/board/{{ board.url_title }}/"> {{ board.title }}</a> &#187;
-  {{ thread.title }}
+  {{ truncate(thread.title) }}
 </span>
 
 <div class="full padded normal">
@@ -56,7 +56,14 @@
   </tr>
   <tr>
     <td class="forum-post-info">
-      <a href="/avatar/"><img src="{{ creator.ha_url }}"></a>
+      <div class="pet-avatar-view">
+        <a href="/avatar/" class="avatar-view">
+          <img src="{{ creator.ha_url }}" />
+        </a>
+        <a href="/pet/shc/" class="active-pet-view">
+          <img src="{{ random_pet_image() }}">
+        </a>
+      </div>
     </td>
     <td class="forum-post-body">
       {{ post.body|markdown }}

--- a/saylua/static-source/scss/assets/_utils.scss
+++ b/saylua/static-source/scss/assets/_utils.scss
@@ -1,0 +1,19 @@
+%alternating-item {
+  @include fast-color-trans;
+  &:nth-child(odd) {
+    background: $mainSoftestColor;
+  }
+
+  &.highlight:nth-child(n) {
+    background-color: $highlightSoftColor;
+  }
+
+  &.highlight:nth-child(odd) {
+    background-color: $highlightColor;
+  }
+
+  // Note: We need the nth-child(n) to overwrite nth-child(even)
+  &:nth-child(n):hover {
+    background-color: $accentSoftColor;
+  }
+}

--- a/saylua/static-source/scss/layout/_layout.scss
+++ b/saylua/static-source/scss/layout/_layout.scss
@@ -8,16 +8,20 @@
 @import 'notifications';
 
 .banner {
+  font-family: $headerFont;
   width: 100%;
   height: 7.6rem;
   padding: 1.8rem;
   text-align: center;
   background: $mainSofterColor url('/static/img/backgrounds/1.jpg');
   background-size: cover;
+  color: $white;
 
   flex-shrink: 0;
 
   .logo {
+    flex-grow: 1;
+    flex-shrink: 0;
     font-size: 4rem;
     font-weight: bold;
 
@@ -25,13 +29,10 @@
       @include filter-trans;
       height: 4rem;
     }
-  }
 
-  .logo:hover img {
-    filter: drop-shadow(0px 0px 5px #eceb72);
-    filter: 'progid:DXImageTransform.Microsoft.Dropshadow(OffX=0, OffY=0, Color=\'#ECEB72\')';
-    -ms-filter: 'progid:DXImageTransform.Microsoft.Dropshadow(OffX=0, OffY=0, Color=\'#ECEB72\')';
-    -webkit-filter: drop-shadow(0px 0px 5px #eceb72);
+    &:hover img {
+      filter: drop-shadow(0px 0px 5px #eceb72);
+    }
   }
 }
 
@@ -39,18 +40,18 @@
   @extend %content-width;
   display: flex;
   flex-direction: row;
-  align-items: flex-start;
   min-height: 400px;
   padding: 1em 0;
 
-  flex-shrink: 0;
+  align-items: flex-start;
   flex-grow: 1;
+  flex-shrink: 0;
 }
 
 .main-body-column {
   display: flex;
   flex-direction: column;
-  margin-top: 0.5rem;
+  margin-top: 0.5em;
 
   align-items: stretch;
   flex-grow: 1;
@@ -79,15 +80,20 @@
   display: flex;
   flex-direction: column;
   width: 20%;
-  padding: 1rem 1%;
+  padding: 1em 1.6rem;
 
+  flex-grow: 0;
   flex-shrink: 0;
 
-  .pet-avatar-view {
-    position: relative;
-    padding-bottom: 1rem;
-    padding-left: 1rem;
+  .active-pet-view:hover {
+    @include bounce-up;
   }
+}
+
+.pet-avatar-view {
+  position: relative;
+  padding-bottom: 1rem;
+  padding-left: 1rem;
 
   .active-pet-view {
     position: absolute;
@@ -95,10 +101,6 @@
     bottom: -1rem;
     left: -1rem;
     width: 80%;
-  }
-
-  .active-pet-view:hover {
-    @include bounce-up;
   }
 }
 
@@ -138,6 +140,7 @@ footer {
 
   .main-body {
     flex-direction: column;
+
     align-items: stretch;
     justify-content: flex-start;
   }

--- a/saylua/static-source/scss/layout/_navbar.scss
+++ b/saylua/static-source/scss/layout/_navbar.scss
@@ -268,7 +268,7 @@ a.navbar-link.active {
 
   .navbar-main-links a.navbar-link {
     line-height: 100%;
-    min-width: 3rem;
+    min-width: 2.5rem;
 
     i {
       font-size: 15px;

--- a/saylua/static-source/scss/layout/assets/_sizes.scss
+++ b/saylua/static-source/scss/layout/assets/_sizes.scss
@@ -11,12 +11,14 @@
 }
 
 @media (max-width: 1100px) {
+  .hide-sidebar %content-width,
   %content-width {
     width: 98%;
   }
 }
 
 @media (max-width: 800px) {
+  .hide-sidebar %content-width,
   %content-width {
     width: 100%;
   }

--- a/saylua/static-source/scss/layout/entities/_main.scss
+++ b/saylua/static-source/scss/layout/entities/_main.scss
@@ -100,17 +100,3 @@ button.link-button, button.link-button:hover {
 a:hover, button.link-button:hover {
   text-decoration: underline;
 }
-
-table {
-  text-align: left;
-}
-
-th {
-  font-weight: bold;
-  text-align: center;
-}
-
-table.colored th {
-  font-weight: normal;
-  background: $mainSofterColor;
-}

--- a/saylua/static-source/scss/utilities.scss
+++ b/saylua/static-source/scss/utilities.scss
@@ -10,6 +10,11 @@ small {
   font-size: $smallFontSize;
 }
 
+// This is a utility class used to specify where text should line break when needed. 
+span.line {
+  display: inline-block;
+}
+
 .center {
   margin: auto;
   text-align: center;

--- a/saylua/templates/layout.html
+++ b/saylua/templates/layout.html
@@ -22,7 +22,6 @@
   {% block header_scripts %}{% endblock %}
 
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Satisfy" rel="stylesheet">
   <!--[if lt IE 9]>
   <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
@@ -30,9 +29,7 @@
 
 <body class="{% if is_admin %}theme-admin{% endif %} {% if fullscreen %}hide-sidebar{% endif %}">
 <div id="banner" class="banner">
-  <a id="logo" href="/" class="logo">
-    <img id="logo-image" src="/static/img/logo.png" alt="Saylua" title="Saylua" />
-  </a>
+  <a id="logo" href="/" class="logo"><img id="logo-image" src="/static/img/logo.png" alt="Saylua" title="Saylua" /></a>
 </div>
 <div id="navbar-container" class="navbar-container">
   <div id="navbar" class="navbar">

--- a/saylua/templates/sidebar.html
+++ b/saylua/templates/sidebar.html
@@ -1,5 +1,5 @@
 <div id="sidebar" class="sidebar">
-  <div id="time-section" class="sidebar-section">
+  <div class="saylua-clock">
     <i class="fa fa-clock-o" aria-hidden="true"></i> <span id="site-time">{{saylua_time|show_time}}</span>
   </div>
   {% if g.logged_in %}
@@ -9,7 +9,7 @@
         <img src="{{g.user.ha_url}}" id="avatar-image" />
       </a>
       <a href="/pet/shc/" id="active-pet-view" class="active-pet-view">
-        <img src="{{ random_pet_image() }}" id="active-pet-image" class="left">
+        <img src="{{ random_pet_image() }}" id="active-pet-image">
       </a>
     </div>
   </div>


### PR DESCRIPTION
I'm really falling behind on this daily screen thing. I will do better! Saylua still has so many screens for me to design/clean up. This changes the boards page to look like this: 

<img width="1270" alt="screenshot 2017-02-20 23 27 28" src="https://cloud.githubusercontent.com/assets/2601991/23154735/36f9c57e-f7c4-11e6-8958-19f1706cb2f7.png">

And when responsive, it's like this: 

<img width="302" alt="screenshot 2017-02-20 23 28 48" src="https://cloud.githubusercontent.com/assets/2601991/23154762/5d20a20e-f7c4-11e6-8d49-8e8c3f7e6f5c.png">

The form to post a new thread still needs work. I want to adjust the form-table class to be some sort of new responsive form component that can be reused across parts of the site nicely. 